### PR TITLE
make `clone-deep` devDependency

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -16,7 +16,6 @@ delegate(receiver, provider, clone);
 
 - `receiver`: (**Object**) The object receiving properties
 - `provider`: (**Object**) The object providing properties
-- `clone`: (**Boolean**) If `true` install `clone-deep` to deep clone the provider object
 
 ## Examples
 
@@ -39,8 +38,8 @@ var receiver = {};
 // object would be overwritten
 delegate(receiver, provider);
 
-receiver.upper('foo'), 'FOO');
-receiver.lower('BAR'), 'bar');
+receiver.upper('foo');
+receiver.lower('BAR');
 
 console.log(receiver.upper('foo')); // 'FOO' 
 console.log(receiver.lower('BAR')); // 'bar'

--- a/.verb.md
+++ b/.verb.md
@@ -16,7 +16,7 @@ delegate(receiver, provider, clone);
 
 - `receiver`: (**Object**) The object receiving properties
 - `provider`: (**Object**) The object providing properties
-- `clone`: (**Boolean**) Pass `true` to deep clone the provider object
+- `clone`: (**Boolean**) If `true` install `clone-deep` to deep clone the provider object
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ delegate(receiver, provider, clone);
 
 * `receiver`: (**Object**) The object receiving properties
 * `provider`: (**Object**) The object providing properties
-* `clone`: (**Boolean**) Pass `true` to deep clone the provider object
 
 ## Examples
 
@@ -44,8 +43,8 @@ var receiver = {};
 // object would be overwritten
 delegate(receiver, provider);
 
-receiver.upper('foo'), 'FOO');
-receiver.lower('BAR'), 'bar');
+receiver.upper('foo');
+receiver.lower('BAR');
 
 console.log(receiver.upper('foo')); // 'FOO' 
 console.log(receiver.lower('BAR')); // 'bar'

--- a/index.js
+++ b/index.js
@@ -16,12 +16,8 @@ var define = require('define-property');
  * @param  {Object} `provider`
  */
 
-module.exports = function delegate(receiver, provider, clone) {
-  if (clone) {
-    provider = require('clone-deep')(provider || receiver);
-  } else {
-    provider = provider || receiver;
-  }
+module.exports = function delegate(receiver, provider) {
+  provider = provider || receiver;
 
   for (var key in provider) {
     define(receiver, key, provider[key]);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@
 
 'use strict';
 
-var cloneDeep = require('clone-deep');
 var define = require('define-property');
 
 /**
@@ -19,7 +18,7 @@ var define = require('define-property');
 
 module.exports = function delegate(receiver, provider, clone) {
   if (clone) {
-    provider = clone(provider || receiver);
+    provider = require('clone-deep')(provider || receiver);
   } else {
     provider = provider || receiver;
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "define-property": "^0.2.5"
   },
   "devDependencies": {
-    "clone-deep": "^0.2.4",
     "mocha": "*"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "test": "mocha"
   },
   "dependencies": {
-    "clone-deep": "^0.2.2",
     "define-property": "^0.2.5"
   },
   "devDependencies": {
+    "clone-deep": "^0.2.4",
     "mocha": "*"
   },
   "keywords": [


### PR DESCRIPTION
Because it is not used by default, and most (or okey exactly mine currently) cases not need deep clone.
But if i (or any other) need deep clone just would install `clone-deep` and it will work.

clone deep have too much deps that are not needed to be installed in the default case
